### PR TITLE
Various improvements

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -23,7 +23,8 @@ def Start():
 
 
 def HttpReq(url, authenticate=True, retry=True):
-    Log("Requesting: %s" % url)
+    if DEBUG:
+        Log("Requesting: %s" % url)
     api_string = ''
     if Prefs['APIKey']:
         api_string = '&apikey=%s' % Prefs['APIKey']
@@ -34,7 +35,8 @@ def HttpReq(url, authenticate=True, retry=True):
         connectstring = 'http://%s:%s/graphql?query=%s%s'
     try:
         connecttoken = connectstring % (Prefs['Hostname'].strip(), Prefs['Port'].strip(), url, api_string)
-        Log(connecttoken)
+        if DEBUG:
+            Log(connecttoken)
         return JSON.ObjectFromString(
             HTTP.Request(connecttoken).content)
     except Exception as e:

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -54,6 +54,7 @@ class StashPlexAgent(Agent.Movies):
         DEBUG = Prefs['debug']
         mediaFile = media.items[0].parts[0].file
         filename = String.Unquote(mediaFile).encode('utf8', 'ignore')
+        filename_clean = os.path.splitext(os.path.basename(filename))[0]
         if (Prefs["UseFullMediaPath"]):
             file_query = r"""query{findScenes(scene_filter:{path:{value:"<FILENAME>",modifier:EQUALS}}){scenes{id,title,date,studio{id,name}}}}"""
         else:
@@ -71,7 +72,7 @@ class StashPlexAgent(Agent.Movies):
                 if scene['date']:
                     title = scene['title'] + ' - ' + scene['date']
                 else:
-                    title = scene['title']
+                    title = filename_clean
                 Log("Title Found: " + title + " Score: " + str(score) + " ID:" + scene['id'])
                 results.Append(MetadataSearchResult(id = str(scene['id']), name = title, score = int(score), lang = lang))
 

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -300,8 +300,10 @@ class StashPlexAgent(Agent.Movies):
                     api_string = '&apikey=%s' % Prefs['APIKey']
                 try:
                     thumb = HTTP.Request(data["paths"]["screenshot"] + api_string)
-                    clear_posters(metadata)
-                    clear_art(metadata)
+                    # TODO: see performance impact vs benefit of these two clear_ methods.
+                    #  Seems to impact IO, and probably shouldn't be needed due to Plex removing old bundles every week.
+                    #clear_posters(metadata)
+                    #clear_art(metadata)
                     metadata.posters[data["paths"]["screenshot"] + api_string] = Proxy.Media(thumb, sort_order=0)
                     metadata.art[data["paths"]["screenshot"] + api_string] = Proxy.Media(thumb, sort_order=0)
                 except Exception as e:

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -1,6 +1,7 @@
 import os
 import dateutil.parser as dateparser
 from urllib2 import quote
+from Helpers import *
 
 # preferences
 preference = Prefs
@@ -45,14 +46,19 @@ class StashPlexAgent(Agent.Movies):
     name = 'Stash Plex Agent'
     languages = [Locale.Language.English]
     primary_provider = True
-    accepts_from = ['com.plexapp.agents.localmedia', 'com.plexapp.agents.xbmcnfo', 'com.plexapp.agents.phoenixadult', 'com.plexapp.agents.data18-phoenix', 'com.plexapp.agents.adultdvdempire']
+    fallback_agent = False
+    contributes_to = None
+    accepts_from = ['com.plexapp.agents.xbmcnfo', 'com.plexapp.agents.phoenixadult', 'com.plexapp.agents.data18-phoenix', 'com.plexapp.agents.adultdvdempire']
 
     def search(self, results, media, lang):
         DEBUG = Prefs['debug']
-        file_query = r"""query{findScenes(scene_filter:{path:{value:"\"<FILENAME>\"",modifier:INCLUDES}}){scenes{id,title,date,studio{id,name}}}}"""
         mediaFile = media.items[0].parts[0].file
         filename = String.Unquote(mediaFile).encode('utf8', 'ignore')
-        filename = os.path.splitext(os.path.basename(filename))[0]
+        if (Prefs["UseFullMediaPath"]):
+            file_query = r"""query{findScenes(scene_filter:{path:{value:"<FILENAME>",modifier:EQUALS}}){scenes{id,title,date,studio{id,name}}}}"""
+        else:
+            file_query = r"""query{findScenes(scene_filter:{path:{value:"\"<FILENAME>\"",modifier:INCLUDES}}){scenes{id,title,date,studio{id,name}}}}"""
+            filename = os.path.splitext(os.path.basename(filename))[0]
         if filename:
             filename = str(quote(filename.encode('UTF-8')))
             query = file_query.replace("<FILENAME>", filename)
@@ -99,6 +105,17 @@ class StashPlexAgent(Agent.Movies):
         else:
             Log("Failed 'Organized' Check, stopping.")
             allow_scrape = False
+
+        if (Prefs["AddOrganizedCollectionTag"] and data["organized"]):
+            Log("Scene marked as organized, adding collection.")
+            if (Prefs["OrganizedCollectionTagName"]):
+                organized_string = Prefs["OrganizedCollectionTagName"]
+            else:
+                organized_string = "Organized"
+            try:
+                metadata.collections.add(organized_string)
+            except:
+                pass
 
         if allow_scrape:
             if data['date']:
@@ -280,9 +297,12 @@ class StashPlexAgent(Agent.Movies):
                     api_string = '&apikey=%s' % Prefs['APIKey']
                 try:
                     thumb = HTTP.Request(data["paths"]["screenshot"] + api_string)
-                    metadata.posters[data["paths"]["screenshot"] + api_string] = Proxy.Preview(thumb, sort_order=0)
-                    metadata.art[data["paths"]["screenshot"] + api_string] = Proxy.Preview(thumb, sort_order=0)
+                    clear_posters(metadata)
+                    clear_art(metadata)
+                    metadata.posters[data["paths"]["screenshot"] + api_string] = Proxy.Media(thumb, sort_order=0)
+                    metadata.art[data["paths"]["screenshot"] + api_string] = Proxy.Media(thumb, sort_order=0)
                 except Exception as e:
+                    Log.Exception('Exception creating posters: %s' % str(e))
                     pass
 
             if Prefs["IncludeGalleryImages"]:
@@ -309,10 +329,10 @@ class StashPlexAgent(Agent.Movies):
                                 if image_orientation == "poster" or image_orientation == "all":
                                     if DEBUG:
                                         Log("Inserting Poster image: " + image["title"] + " (" + str(image["file"]["width"]) + "x" + str(image["file"]["height"]) + " WxH)")
-                                    metadata.posters[imageurl] = Proxy.Preview(thumb)
+                                    metadata.posters[imageurl] = Proxy.Media(thumb)
                                 if image_orientation == "background" or image_orientation == "all":
                                     if DEBUG:
                                         Log("Inserting Background image: " + image["title"] + " (" + str(image["file"]["width"]) + "x" + str(image["file"]["height"]) + " WxH)")
-                                        metadata.art[imageurl] = Proxy.Preview(thumb)
+                                        metadata.art[imageurl] = Proxy.Media(thumb)
                             except Exception as e:
                                 pass

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -1,7 +1,7 @@
 import os
 import dateutil.parser as dateparser
 from urllib2 import quote
-from Helpers import *
+#from Helpers import *
 
 # preferences
 preference = Prefs

--- a/Contents/DefaultPrefs.json
+++ b/Contents/DefaultPrefs.json
@@ -24,6 +24,12 @@
         "default": ""
     },
     {
+        "id": "UseFullMediaPath",
+        "label": "Query the entire file path while matching in Stash. Use only if the folder path in Stash is the same as in Plex.",
+        "type": "bool",
+        "default": false
+    },
+    {
         "id": "IncludeGalleryImages",
         "label": "Include attached Gallery images in addition to default poster?",
         "type": "bool",
@@ -52,6 +58,18 @@
         "label": "Stash Tag ID numbers create Collections from (comma separated, 0 to disable)",
         "type": "text",
         "default": "0"
+    },
+    {
+        "id": "AddOrganizedCollectionTag",
+        "label": "Auto add media marked as organized into a Plex Collection",
+        "type": "bool",
+        "default": false
+    },
+    {
+        "id": "OrganizedCollectionTagName",
+        "label": "Name for the collection containing all media marked as organized in Stash",
+        "type": "text",
+        "default": "Organized"
     },
     {
         "id": "CreateAllTagCollectionTags",

--- a/Libraries/Shared/Helpers.py
+++ b/Libraries/Shared/Helpers.py
@@ -1,0 +1,5 @@
+def clear_posters(metadata):
+    metadata.posters._items.clear()
+
+def clear_art(metadata):
+    metadata.art._items.clear()


### PR DESCRIPTION
- Don't include localmedia in accepts_from. This might be controversial for people who want local metadata for some reason, but [in my opinion it's better without](https://github.com/Darklyter/StashPlexAgent.bundle/issues/13#issuecomment-1412682652). Probably fixes #13 
- Add option to query Stash API using the full media path. Fixes #16 and possibly #15 
- Add option to create an "organized" collection. Resolves #17 
- Use `Proxy.Media` instead of `Proxy.Preview` for banners. How I read [Plex's archived documentation](https://web.archive.org/web/20150113085312/http://dev.plexapp.com/docs/agents/models.html#proxy-objects), it seems like the more logical choice -- it's hard to confirm, but I think `.Media` method does some sort of processing that would help with storage compared to the existing method; images on Stash even from stashdb can be quite large.
- Provide filename as "title" when information is missing from stash instance. Fixes #19
- Quiet down logging -- it was previously logging all HttpReq despite debug flag.