### PR TITLE
feat(ratings): add option to sync stash ratings to plex media items

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -1,6 +1,5 @@
-import os
+import os, urllib, urllib2, json
 import dateutil.parser as dateparser
-from urllib2 import quote
 #from Helpers import *
 
 # preferences
@@ -63,7 +62,7 @@ class StashPlexAgent(Agent.Movies):
             file_query = r"""query{findScenes(scene_filter:{path:{value:"\"<FILENAME>\"",modifier:INCLUDES}}){scenes{id,title,date,studio{id,name}}}}"""
             filename = os.path.splitext(os.path.basename(filename))[0]
         if filename:
-            filename = str(quote(filename.encode('UTF-8')))
+            filename = str(urllib2.quote(filename.encode('UTF-8')))
             query = file_query.replace("<FILENAME>", filename)
             request = HttpReq(query)
             if DEBUG:
@@ -83,7 +82,7 @@ class StashPlexAgent(Agent.Movies):
         DEBUG = Prefs['debug']
         Log("update(%s)" % metadata.id)
         mid = metadata.id
-        id_query = "query{findScene(id:%s){path,id,title,details,url,date,rating,paths{screenshot,stream}movies{movie{id,name}}studio{id,name,image_path,parent_studio{id,name,details}}organized,stash_ids{stash_id}tags{id,name}performers{name,image_path,tags{id,name}}movies{movie{name}}galleries{id,title,url,images{id,title,path,file{size,width,height}}}}}"
+        id_query = "query{findScene(id:%s){path,id,title,details,url,date,rating,rating100,paths{screenshot,stream}movies{movie{id,name}}studio{id,name,image_path,parent_studio{id,name,details}}organized,stash_ids{stash_id}tags{id,name}performers{name,image_path,tags{id,name}}movies{movie{name}}galleries{id,title,url,images{id,title,path,file{size,width,height}}}}}"
         data = HttpReq(id_query % mid)
         data = data['data']['findScene']
         metadata.collections.clear()
@@ -144,7 +143,8 @@ class StashPlexAgent(Agent.Movies):
 
             # Get the rating
             if not data["rating"] is None:
-                metadata.rating = float(data["rating"]) * 2
+                stashRating = float(data["rating100"] / 10)
+                metadata.rating = stashRating
                 if Prefs["CreateRatingTags"]:
                     if int(data["rating"]) > 0:
                         rating = str(int(data["rating"]))
@@ -153,6 +153,56 @@ class StashPlexAgent(Agent.Movies):
                             metadata.collections.add(ratingstring)
                         except:
                             pass
+                if Prefs["SaveUserRatings"]:
+                    # set stash rating to plex rating
+                    if not stashRating is None:
+                        Log('Set media rating to %s' % stashRating)
+                        host = "http://127.0.0.1:32400"
+                        token = os.environ['PLEXTOKEN']
+
+                        # get section details
+                        # inspired by https://github.com/suparngp/plex-personal-shows-agent.bundle/blob/master/Contents/Code/__init__.py#L31
+                        sectionQueryEncoded = urllib.urlencode({
+                            "X-Plex-Token": token
+                        })
+                        section_lookup_url = '{host}/library/metadata/{media_id}?{sectionQueryEncoded}'.format(
+                            host=host,
+                            media_id=media.id,
+                            sectionQueryEncoded=sectionQueryEncoded
+                        )
+                        if DEBUG:
+                            Log('Section lookup request: %s' % section_lookup_url)
+                        metadata = json.loads(HTTP.Request(url=section_lookup_url, immediate=True, headers={'Accept': 'application/json'}).content)
+                        
+                        identifier = metadata['MediaContainer']['identifier']
+                        rating_key = metadata['MediaContainer']['Metadata'][0]['ratingKey']
+                        userRating = metadata['MediaContainer']['Metadata'][0]['userRating']
+                        
+                        if float(userRating) != float(stashRating):
+                            rateQueryEncoded = urllib.urlencode({
+                                "key": rating_key,
+                                "identifier": identifier,
+                                "rating": stashRating,
+                                "X-Plex-Token": token
+                            })
+                            rateUrl = '{host}/:/rate?{rateQueryEncoded}'.format(
+                                host=host,
+                                rateQueryEncoded=rateQueryEncoded
+                            )
+                            if DEBUG:
+                                Log('Rate request: %s' % rateUrl)
+                            # inspired by https://github.com/pkkid/python-plexapi/blob/9b8c7d522d1ca94a0782b940c03d257d8dd071a0/plexapi/mixins.py#L317
+                            request = urllib2.Request(url=rateUrl, data=urllib.urlencode({'dummy':'dummy'}), headers={
+                                'Content-Type': 'text/html',
+                            })
+                            request.get_method = lambda: 'GET'
+                            response = urllib2.urlopen(request)
+                            if DEBUG:
+                                Log("setUserRating: response: %s" % response.read())
+                        else:
+                            Log("User rating %s already set to %s" % (userRating, stashRating))
+                    else:
+                        Log("Media has no user rating, skipping")
 
             # Set the summary
             if data['details']:

--- a/Contents/DefaultPrefs.json
+++ b/Contents/DefaultPrefs.json
@@ -138,6 +138,12 @@
         "default": false
     },
     {
+        "id": "SaveUserRatings",
+        "label": "Auto sync Stash ratings to Plex user ratings",
+        "type": "bool",
+        "default": false
+    },
+    {
         "id": "RequireOrganized",
         "label": "Require Organized flag to be set in Stash to pull metadata",
         "type": "bool",
@@ -160,5 +166,5 @@
         "label": "Use debug logging",
         "type": "bool",
         "default": false
-    },
+    }
 ]


### PR DESCRIPTION
In an effort to keep my ratings save in my stashdb, I setup stash > plex rating sync

- stash ratings get saved as user ratings in plex on metadata refresh
- stash ratings become plex stars
- uses plex api `/:/rating` endpoint (plex scene update `userRatings` did not work)
- uses `PLEXTOKEN` set in env var (plex automatically sets in agent, no PMS changes required)


## Todo
- [ ] Round ratings to nearest whole or half-star (ie. `1.0` or `1.5`) to maximize plex player compatibility
- [ ] Remove unused `rating` from graphql id query (now that we're using `rating100`)
- [ ] Use `rating100` instead of `rating` everywhere
- [ ] wrap info `Log` in `DebugLog` to conditionally log based on `DEBUG`