### PR TITLE
feat(formatted titles): add text format with variables to customize title

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -59,6 +59,7 @@ def FormattedTitle(data, fallback_title=None):
         return fallback_title
     else:
         performer = ""
+        studio = ""
         date = data['date']
         title = data['title']
         if "performer" in title_format:
@@ -88,8 +89,15 @@ def FormattedTitle(data, fallback_title=None):
                     title = remove_prefix(title, performer)
                     title = remove_prefix(title, " - ")
                     title = title.strip()
+        if "studio" in title_format:
+            studio = data['studio']['name']
 
-        title = title_format.format(performer=performer, title=title, date=data['date'])
+        title = title_format.format(
+            performer=performer,
+            title=title,
+            date=data['date'],
+            studio=studio
+        )
     return title
 
 

--- a/Contents/DefaultPrefs.json
+++ b/Contents/DefaultPrefs.json
@@ -30,6 +30,18 @@
         "default": false
     },
     {
+        "id": "UseFormattedTitle",
+        "label": "Use a formatted title for Plex using Stash metadata",
+        "type": "bool",
+        "default": false
+    },
+    {
+        "id": "TitleFormat",
+        "label": "Title format to use if enabled (available variables: performer, title, date). <br />Use ignore tags and add tag to performer to have it ignored during naming.",
+        "type": "text",
+        "default": "{performer} - {title}"
+    },
+    {
         "id": "IncludeGalleryImages",
         "label": "Include attached Gallery images in addition to default poster?",
         "type": "bool",
@@ -160,5 +172,5 @@
         "label": "Use debug logging",
         "type": "bool",
         "default": false
-    },
+    }
 ]

--- a/Contents/DefaultPrefs.json
+++ b/Contents/DefaultPrefs.json
@@ -37,7 +37,7 @@
     },
     {
         "id": "TitleFormat",
-        "label": "Title format to use if enabled (available variables: performer, title, date). <br />Use ignore tags and add tag to performer to have it ignored during naming.",
+        "label": "Title format to use if enabled (available variables: performer, title, date, studio). Use IgnoreTags to ignore a performer from title.",
         "type": "text",
         "default": "{performer} - {title}"
     },


### PR DESCRIPTION
I prefer to have the performer name start the title, so it's easier to sort in plex

This feature can be turned on to format titles using variables:
- title (stash title)
- performer
- date
- studio

Example: `{performer} - {title} ({date}) [{studio}]`

Would produce something like:

`Jane Doe - My First Video (2023-01-01) [Studio Films]`

## Review Todo

- [ ] Add check and fallback to avoid an empty string on the manual matching dialogue in Plex [#discussion_r1111013350](https://github.com/Darklyter/StashPlexAgent.bundle/pull/22#discussion_r1111013350)