### PR TITLE
Fix handling of filenames with double quotes in the path.

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -119,7 +119,8 @@ class StashPlexAgent(Agent.Movies):
             file_query = r"""query{findScenes(scene_filter:{path:{value:"\"<FILENAME>\"",modifier:INCLUDES}}){scenes{id,title,date,studio{id,name}}}}"""
             filename = os.path.splitext(os.path.basename(filename))[0]
         if filename:
-            filename = str(urllib2.quote(filename.encode('UTF-8')))
+            filename = filename.replace('"', r'\"')
+            filename = urllib2.quote(filename.encode('UTF-8'))
             query = file_query.replace("<FILENAME>", filename)
             request = HttpReq(query)
             if DEBUG:

--- a/Contents/DefaultPrefs.json
+++ b/Contents/DefaultPrefs.json
@@ -9,7 +9,7 @@
         "id": "Port",
         "label": "The port for Stash",
         "type": "text",
-        "default": "9999"
+        "default": "8009"
     },
     {
         "id": "UseHTTPS",
@@ -63,7 +63,7 @@
         "id": "IgnoreTags",
         "label": "Stash Tag ID numbers to ignore (comma separated, 0 to disable)",
         "type": "text",
-        "default": "1,2,3318,6279"
+        "default": "0"
     },
     {
         "id": "CreateTagCollectionTags",

--- a/Contents/DefaultPrefs.json
+++ b/Contents/DefaultPrefs.json
@@ -9,7 +9,7 @@
         "id": "Port",
         "label": "The port for Stash",
         "type": "text",
-        "default": "8009"
+        "default": "9999"
     },
     {
         "id": "UseHTTPS",
@@ -63,7 +63,7 @@
         "id": "IgnoreTags",
         "label": "Stash Tag ID numbers to ignore (comma separated, 0 to disable)",
         "type": "text",
-        "default": "0"
+        "default": "1,2,3318,6279"
     },
     {
         "id": "CreateTagCollectionTags",
@@ -180,3 +180,4 @@
         "default": false
     }
 ]
+


### PR DESCRIPTION
These kinds of filenames were previously unmatched due to incorrect escaping. This fixes the escaping. Tested on many files with double quotes in the names.