### PR TITLE
Add {filename} as variable for formatted titles

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -2,7 +2,6 @@ import os, urllib, urllib2, json
 import dateutil.parser as dateparser
 #from Helpers import *
 import copy
-import re
 
 # preferences
 preference = Prefs
@@ -92,12 +91,16 @@ def FormattedTitle(data, fallback_title=None):
                     title = title.strip()
         if "studio" in title_format:
             studio = data['studio']['name']
+        
+        if "filename" in title_format:
+            clean_filename = os.path.splitext(os.path.basename(data["files"][0]["path"]))[0]
 
         title = title_format.format(
             performer=performer,
             title=title,
             date=data['date'],
-            studio=studio
+            studio=studio,
+            filename=clean_filename
         )
     return title
 
@@ -144,7 +147,7 @@ class StashPlexAgent(Agent.Movies):
         DEBUG = Prefs['debug']
         Log("update(%s)" % metadata.id)
         mid = metadata.id
-        id_query = "query{findScene(id:%s){id,title,details,url,date,rating100,paths{screenshot,stream}movies{movie{id,name}}studio{id,name,image_path,parent_studio{id,name,details}}organized,stash_ids{stash_id}tags{id,name}performers{name,image_path,tags{id,name}}movies{movie{name}}galleries{id,title,url}}}"
+        id_query = "query{findScene(id:%s){id,title,details,url,date,files{path},rating100,paths{screenshot,stream}movies{movie{id,name}}studio{id,name,image_path,parent_studio{id,name,details}}organized,stash_ids{stash_id}tags{id,name}performers{name,image_path,tags{id,name}}movies{movie{name}}galleries{id,title,url}}}"
         data = HttpReq(id_query % mid)
         data = data['data']['findScene']
         metadata.collections.clear()
@@ -279,9 +282,6 @@ class StashPlexAgent(Agent.Movies):
             if data['details']:
                 summary = data["details"].replace("\n", " ").replace("\r", "").replace("\t", "")
                 metadata.summary = summary
-              
-                # Remove non-printable characters
-                summary = re.sub(r"[\x00-\x1F\x7F-\x9F]", "", summary)              
 
             # Set series and add to collections
             if Prefs["CreateSiteCollectionTags"]:

--- a/Contents/DefaultPrefs.json
+++ b/Contents/DefaultPrefs.json
@@ -43,7 +43,7 @@
     },
     {
         "id": "TitleFormat",
-        "label": "Title format to use if enabled (available variables: performer, title, date, studio). Use IgnoreTags to ignore a performer from title.",
+        "label": "Title format to use if enabled (available variables: performer, title, date, studio, filename). Use IgnoreTags to ignore a performer from title.",
         "type": "text",
         "default": "{performer} - {title}"
     },


### PR DESCRIPTION
added {filename} to the formatted title variables, if the original filename is relevant (e.g. running Kometa based on a specific naming convention)